### PR TITLE
More v0.4 improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,20 +11,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - uses: actions/checkout@v3
       with:
         submodules: true
+
+    - id: skip_check
+      name: Skip Check
+      uses: fkirc/skip-duplicate-actions@master
+      with:
+        concurrent_skipping: 'same_content_newer'
+        paths_ignore: '["**.md"]'
+
     - name: Build
       run: make build
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+
     - name: Lint
       run: make lint
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+
     - name: Format Check
       run: make fmt-check
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+
     - name: Run tests
       run: make test
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+
     - name: Run shell tests
       run: make test-cmd
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+
     - name: Run integration pose → docker → network tests
       run: make test-integration
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+
     - name: Run shell integration pose → docker → network tests
       run: make test-cmd-integration
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "docker-pose"
-version = "0.4.0-b1"
+version = "0.4.0-b2"
 dependencies = [
  "clap",
  "clap-num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-pose"
-version = "0.4.0-b1"
+version = "0.4.0-b2"
 edition = "2021"
 authors = ["Mariano Ruiz <mrsarm@gmail.com>"]
 description = "Command line tool to play with 🐳 Docker Compose files."

--- a/Run-CI-envs.md
+++ b/Run-CI-envs.md
@@ -252,19 +252,19 @@ related with rate limits reached.
 #### Filters
 
 The other argument that allows to speed up the process (and avoid rate limits
-from the docker registry) is `--remote-tag-filter FILTER`, filtering _in_ or _out_
+from the docker registry) is `--tag-filter FILTER`, filtering _in_ or _out_
 what images to check whether a remote tag exists or not when replacing images.
 `FILTER` can be an expression like `regex=NAME` (`=` → _filter ‒ in_) or `regex!=EXPR`
 (`!=` → _filter ‒ out_), where `EXPR` is a regex expression. In our example, all the apps we
 build start with the `mrsarm/` prefix, while other services like the DBs one don't,
 so the best way to check only our apps while ignoring the rest when replacing the tag in
-the image field of each service is using the argument `--remote-tag-filter regex='mrsarm/'`.
+the image field of each service is using the argument `--tag-filter regex='mrsarm/'`.
 The resulting `ci.yaml` will be identical than not using the filter at all, because it's
 unlikely and even undesired to have an official Postgres image `postgres:client-vat-field`,
 but more importantly, the execution in our CI pipeline will be much faster.
 
 ```
-pose config --remote-tag "$GITHUB_REF" --remote-tag-filter regex='mrsarm/' -o ci.yaml --remote-progress
+pose config --remote-tag "$GITHUB_REF" --tag-filter regex='mrsarm/' -o ci.yaml --remote-progress
 
 DEBUG: remote manifest for image postgres ... skipped 
 DEBUG: remote manifest for image rabbitmq ... skipped
@@ -281,5 +281,5 @@ it's an _exclusion_ expression, all images with the string `postgres` or `rabbit
 on it will be ignored when replacing tags:
 
 ```shell
-pose config --remote-tag "$GITHUB_REF" --remote-tag-filter regex!='postgres|rabbitmq' -o ci.yaml --remote-progress
+pose config --remote-tag "$GITHUB_REF" --tag-filter regex!='postgres|rabbitmq' -o ci.yaml --remote-progress
 ```

--- a/Run-CI-envs.md
+++ b/Run-CI-envs.md
@@ -168,24 +168,24 @@ error like `manifest for mrsarm/api-worker:client-vat-field not found`.
 In the example above you only need to run the services with the tag `client-vat-field`
 if the tag exists in the registry to be pulled of by compose, otherwise keep using the
 same `latest` tag set in the compose file, or whatever tag is set. You can achieve this with
-the command `pose config` using the `--remote-tag TAG` argument, that like
+the command `pose config` using the `--tag TAG` argument, that like
 `docker compose config` it outputs a new compose file but pre-processing it according to
 the arguments received. The following will output a new `ci.yaml` file with the desired
 output, while showing in the terminal (or the CI logs) what is doing while fetching the
 information from the docker registry:
 
 ```shell
-pose config --remote-tag "$GITHUB_REF" --remote-progress -o ci.yaml
+pose config --tag "$GITHUB_REF" --progress -o ci.yaml
 ```
 
 The remote progress will look like the following:
 
 ```
-DEBUG: remote manifest for image mrsarm/web:client-vat-field ... found 
-DEBUG: remote manifest for image mrsarm/api-worker:client-vat-field ... not found 
-DEBUG: remote manifest for image postgres:client-vat-field ... not found 
-DEBUG: remote manifest for image mrsarm/api:client-vat-field ... found 
-DEBUG: remote manifest for image rabbitmq:client-vat-field ... not found 
+DEBUG: manifest for image mrsarm/web:client-vat-field ... found 
+DEBUG: manifest for image mrsarm/api-worker:client-vat-field ... not found 
+DEBUG: manifest for image postgres:client-vat-field ... not found 
+DEBUG: manifest for image mrsarm/api:client-vat-field ... found 
+DEBUG: manifest for image rabbitmq:client-vat-field ... not found 
 ```
 
 In the progress shown we can see the images found with the tag `client-vat-field`
@@ -264,13 +264,13 @@ unlikely and even undesired to have an official Postgres image `postgres:client-
 but more importantly, the execution in our CI pipeline will be much faster.
 
 ```
-pose config --remote-tag "$GITHUB_REF" --tag-filter regex='mrsarm/' -o ci.yaml --remote-progress
+pose config --tag "$GITHUB_REF" --tag-filter regex='mrsarm/' -o ci.yaml --progress
 
-DEBUG: remote manifest for image postgres ... skipped 
-DEBUG: remote manifest for image rabbitmq ... skipped
-DEBUG: remote manifest for image mrsarm/web:client-vat-field ... found 
-DEBUG: remote manifest for image mrsarm/api-worker:client-vat-field ... not found 
-DEBUG: remote manifest for image mrsarm/api:client-vat-field ... found 
+DEBUG: manifest for image postgres ... skipped 
+DEBUG: manifest for image rabbitmq ... skipped
+DEBUG: manifest for image mrsarm/web:client-vat-field ... found 
+DEBUG: manifest for image mrsarm/api-worker:client-vat-field ... not found 
+DEBUG: manifest for image mrsarm/api:client-vat-field ... found 
 ```
 
 Use a _filter ‒ out_ expression when not all images follow certain convention like
@@ -281,5 +281,5 @@ it's an _exclusion_ expression, all images with the string `postgres` or `rabbit
 on it will be ignored when replacing tags:
 
 ```shell
-pose config --remote-tag "$GITHUB_REF" --tag-filter regex!='postgres|rabbitmq' -o ci.yaml --remote-progress
+pose config --tag "$GITHUB_REF" --tag-filter regex!='postgres|rabbitmq' -o ci.yaml --progress
 ```

--- a/src/args.rs
+++ b/src/args.rs
@@ -84,7 +84,7 @@ pub enum Commands {
         /// whether the remote tag exists or not.
         /// Currently only regex=EXPR or regex!=EXPR are supported
         #[arg(long, value_name = "FILTER", requires("remote_tag"), value_parser = string_no_empty)]
-        remote_tag_filter: Option<String>,
+        tag_filter: Option<String>,
         /// ignore unauthorized errors from docker when fetching remote tags info
         #[arg(long, requires("remote_tag"))]
         ignore_unauthorized: bool,
@@ -134,7 +134,7 @@ pub enum Objects {
         /// printed with the tag they have in the compose file.
         /// Currently only regex=EXPR or regex!=EXPR are supported
         #[arg(long, value_name = "FILTER", requires("remote_tag"), value_parser = string_no_empty)]
-        remote_tag_filter: Option<String>,
+        tag_filter: Option<String>,
         /// ignore unauthorized errors from docker when fetching remote tags info
         #[arg(long, requires("remote_tag"))]
         ignore_unauthorized: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -54,6 +54,14 @@ fn positive_less_than_32(s: &str) -> Result<u8, String> {
     number_range(s, 1, 32)
 }
 
+fn string_no_empty(s: &str) -> Result<String, String> {
+    if s.len() >= 1 {
+        Ok(s.to_string())
+    } else {
+        Err("must be at least 1 character long".to_string())
+    }
+}
+
 #[derive(Subcommand)]
 pub enum Commands {
     /// List objects found in the compose file: services, volumes, ...
@@ -71,12 +79,12 @@ pub enum Commands {
         output: Option<String>,
         /// output with remote tag passed instead of the one set in the file
         /// if exists in the docker registry
-        #[arg(short, long, value_name = "TAG")]
+        #[arg(short, long, value_name = "TAG", value_parser = string_no_empty)]
         remote_tag: Option<String>,
         /// use with --remote-tag to filter which images should be checked
         /// whether the remote tag exists or not.
         /// Currently only regex=EXPR or regex!=EXPR are supported
-        #[arg(long, value_name = "FILTER", requires("remote_tag"))]
+        #[arg(long, value_name = "FILTER", requires("remote_tag"), value_parser = string_no_empty)]
         remote_tag_filter: Option<String>,
         /// ignore unauthorized errors from docker when fetching remote tags info
         #[arg(long, requires("remote_tag"))]
@@ -101,6 +109,7 @@ pub enum Commands {
     /// compatible with a valid docker tag name.
     Slug {
         /// text to slugify, if not provided the current branch name is used
+        #[arg(value_parser = string_no_empty)]
         text: Option<String>,
     },
 }
@@ -118,14 +127,14 @@ pub enum Objects {
         filter: Option<String>,
         /// print with remote tag passed instead of the one set in the file
         /// if exists in the docker registry
-        #[arg(short, long, value_name = "TAG")]
+        #[arg(short, long, value_name = "TAG", value_parser = string_no_empty)]
         remote_tag: Option<String>,
         /// use with --remote-tag to filter which images should be checked
         /// whether the remote tag exists or not, but images that don't match
         /// the filter are not filtered out from the list printed, only
         /// printed with the tag they have in the compose file.
         /// Currently only regex=EXPR or regex!=EXPR are supported
-        #[arg(long, value_name = "FILTER", requires("remote_tag"))]
+        #[arg(long, value_name = "FILTER", requires("remote_tag"), value_parser = string_no_empty)]
         remote_tag_filter: Option<String>,
         /// ignore unauthorized errors from docker when fetching remote tags info
         #[arg(long, requires("remote_tag"))]
@@ -154,7 +163,10 @@ pub enum Objects {
     /// List profiles
     Profiles,
     /// List service's environment variables
-    Envs { service: String },
+    Envs {
+        #[arg(value_parser = string_no_empty)]
+        service: String
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, strum_macros::Display)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,11 +55,10 @@ fn positive_less_than_32(s: &str) -> Result<u8, String> {
 }
 
 fn string_no_empty(s: &str) -> Result<String, String> {
-    if s.len() >= 1 {
-        Ok(s.to_string())
-    } else {
-        Err("must be at least 1 character long".to_string())
+    if s.is_empty() {
+        return Err("must be at least 1 character long".to_string());
     }
+    Ok(s.to_string())
 }
 
 #[derive(Subcommand)]
@@ -165,7 +164,7 @@ pub enum Objects {
     /// List service's environment variables
     Envs {
         #[arg(value_parser = string_no_empty)]
-        service: String
+        service: String,
     },
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -91,7 +91,10 @@ pub enum Commands {
         /// Don't slugify the value from --tag
         #[arg(long, requires("tag"))]
         no_slug: bool,
-        /// Outputs in stderr the progress of fetching the tags info, similar to --verbose,
+        /// only check --tag TAG with the local docker registry
+        #[arg(long, requires("tag"))]
+        offline: bool,
+        /// outputs in stderr the progress of fetching the tags info, similar to --verbose,
         /// but without all the other details --verbose adds
         #[arg(long, requires("tag"))]
         progress: bool,
@@ -140,7 +143,10 @@ pub enum Objects {
         /// Don't slugify the value from --tag
         #[arg(long, requires("tag"))]
         no_slug: bool,
-        /// Outputs in stderr the progress of fetching the tags info, similar to --verbose
+        /// only check --tag TAG with the local docker registry
+        #[arg(long, requires("tag"))]
+        offline: bool,
+        /// outputs in stderr the progress of fetching the tags info, similar to --verbose
         /// but without all the other details --verbose adds
         #[arg(long, requires("tag"))]
         progress: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -76,33 +76,33 @@ pub enum Commands {
         /// Save to file (default to stdout)
         #[arg(short, long, value_name = "FILE")]
         output: Option<String>,
-        /// output with remote tag passed instead of the one set in the file
-        /// if exists in the docker registry
+        /// output image attributes in services with tag passed instead of the one set in the file
+        /// if they exist locally or in the remote docker registry
         #[arg(short, long, value_name = "TAG", value_parser = string_no_empty)]
-        remote_tag: Option<String>,
-        /// use with --remote-tag to filter which images should be checked
-        /// whether the remote tag exists or not.
+        tag: Option<String>,
+        /// use with --tag to filter which images should be checked whether the
+        /// tag exists or not locally or remotely.
         /// Currently only regex=EXPR or regex!=EXPR are supported
-        #[arg(long, value_name = "FILTER", requires("remote_tag"), value_parser = string_no_empty)]
+        #[arg(long, value_name = "FILTER", requires("tag"), value_parser = string_no_empty)]
         tag_filter: Option<String>,
         /// ignore unauthorized errors from docker when fetching remote tags info
-        #[arg(long, requires("remote_tag"))]
+        #[arg(long, requires("tag"))]
         ignore_unauthorized: bool,
-        /// Don't slugify the value from --remote-tag
-        #[arg(long, requires("remote_tag"))]
+        /// Don't slugify the value from --tag
+        #[arg(long, requires("tag"))]
         no_slug: bool,
-        /// Outputs in stderr the progress of fetching remote tags, similar to the --verbose argument,
+        /// Outputs in stderr the progress of fetching the tags info, similar to --verbose,
         /// but without all the other details --verbose adds
-        #[arg(long, requires("remote_tag"))]
-        remote_progress: bool,
+        #[arg(long, requires("tag"))]
+        progress: bool,
         /// max number of threads used to fetch remote images info
-        #[arg(long, value_name = "NUM", default_value_t = 4, value_parser = positive_less_than_32, requires("remote_tag"))]
+        #[arg(long, value_name = "NUM", default_value_t = 4, value_parser = positive_less_than_32, requires("tag"))]
         threads: u8,
     },
     /// Outputs a slug version of the text passed, or the slug version of the
     /// current branch.
     ///
-    /// It's the same slug used with the --remote-tag value in other commands.
+    /// It's the same slug used with the --tag value in other commands.
     /// The output is a lowercase version with all no-alphanumeric
     /// characters translated into the "-" symbol, except for the char ".", to make it
     /// compatible with a valid docker tag name.
@@ -119,34 +119,33 @@ pub enum Objects {
     Services,
     /// List images
     Images {
-        /// filter by a property, if --remote-tag is used as well,
+        /// filter by a property, if --tag is used as well,
         /// this filter is applied first, filtering out images that
         /// don't match the filter. Currently only tag=TAG is supported
         #[arg(short, long)]
         filter: Option<String>,
-        /// print with remote tag passed instead of the one set in the file
-        /// if exists in the docker registry
+        /// print images with the tag passed instead of the one set in the file if they exist
+        /// locally or in the remote docker registry
         #[arg(short, long, value_name = "TAG", value_parser = string_no_empty)]
-        remote_tag: Option<String>,
-        /// use with --remote-tag to filter which images should be checked
-        /// whether the remote tag exists or not, but images that don't match
-        /// the filter are not filtered out from the list printed, only
-        /// printed with the tag they have in the compose file.
+        tag: Option<String>,
+        /// use with --tag to filter which images should be checked whether the tag exists
+        /// or not, but images that don't match the filter are not filtered out from the list
+        /// printed, only printed with the tag they have in the compose file.
         /// Currently only regex=EXPR or regex!=EXPR are supported
-        #[arg(long, value_name = "FILTER", requires("remote_tag"), value_parser = string_no_empty)]
+        #[arg(long, value_name = "FILTER", requires("tag"), value_parser = string_no_empty)]
         tag_filter: Option<String>,
         /// ignore unauthorized errors from docker when fetching remote tags info
-        #[arg(long, requires("remote_tag"))]
+        #[arg(long, requires("tag"))]
         ignore_unauthorized: bool,
-        /// Don't slugify the value from --remote-tag
-        #[arg(long, requires("remote_tag"))]
+        /// Don't slugify the value from --tag
+        #[arg(long, requires("tag"))]
         no_slug: bool,
-        /// Outputs in stderr the progress of fetching remote tags, similar to the --verbose argument,
+        /// Outputs in stderr the progress of fetching the tags info, similar to --verbose
         /// but without all the other details --verbose adds
-        #[arg(long, requires("remote_tag"))]
-        remote_progress: bool,
-        /// max number of threads used to fetch remote images info
-        #[arg(long, value_name = "NUM", default_value_t = 4, value_parser = positive_less_than_32, requires("remote_tag"))]
+        #[arg(long, requires("tag"))]
+        progress: bool,
+        /// max number of threads used to fetch images info
+        #[arg(long, value_name = "NUM", default_value_t = 4, value_parser = positive_less_than_32, requires("tag"))]
         threads: u8,
     },
     /// List service's depends_on

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -94,6 +94,10 @@ impl DockerCommand {
         self.call_cmd(&["manifest", "inspect", "--insecure", image], false, false)
     }
 
+    pub fn get_image_inspect(&self, image: &str) -> io::Result<Output> {
+        self.call_cmd(&["image", "inspect", image], false, false)
+    }
+
     pub fn write_stderr(&self, stderr: &[u8]) {
         cmd_write_stderr(&self.docker_bin, stderr);
     }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -98,6 +98,15 @@ impl DockerCommand {
         self.call_cmd(&["image", "inspect", image], false, false)
     }
 
+    pub fn pull_image(
+        &self,
+        image: &str,
+        output_stdout: bool,
+        output_stderr: bool,
+    ) -> io::Result<Output> {
+        self.call_cmd(&["pull", image], output_stdout, output_stderr)
+    }
+
     pub fn write_stderr(&self, stderr: &[u8]) {
         cmd_write_stderr(&self.docker_bin, stderr);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use cmd::{
 };
 pub use docker::DockerCommand;
 pub use git::GitCommand;
-pub use parse::{get_compose_filename, ComposeYaml, RemoteTag};
+pub use parse::{get_compose_filename, ComposeYaml, ReplaceTag};
 pub use utils::{
     get_service, get_slug, get_yml_content, print_names, unwrap_filter_regex, unwrap_filter_tag,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::{fs, process};
 use docker_pose::{
     cmd_get_success_output_or_fail, get_service, get_slug, get_yml_content, print_names,
     unwrap_filter_regex, unwrap_filter_tag, Args, Commands, ComposeYaml, DockerCommand, GitCommand,
-    Objects, RemoteTag, Verbosity,
+    Objects, ReplaceTag, Verbosity,
 };
 
 fn main() {
@@ -137,7 +137,7 @@ fn main() {
             } => {
                 let tag = unwrap_filter_tag(filter.as_deref());
                 let regex = unwrap_filter_regex(tag_filter.as_deref());
-                let remote_tag = remote_tag.map(|tag| RemoteTag {
+                let remote_tag = remote_tag.map(|tag| ReplaceTag {
                     ignore_unauthorized,
                     threads,
                     no_slug,
@@ -181,7 +181,7 @@ fn main() {
             threads,
         } => {
             let regex = unwrap_filter_regex(tag_filter.as_deref());
-            let remote_tag = remote_tag.map(|tag| RemoteTag {
+            let remote_tag = remote_tag.map(|tag| ReplaceTag {
                 ignore_unauthorized,
                 threads,
                 no_slug,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! `pose` is a command line tool to play with 🐳 Docker Compose files.
 
 use clap::Parser;
-use colored::Colorize;
+use colored::*;
 use std::{fs, process};
 
 //mod lib;
@@ -13,6 +13,7 @@ use docker_pose::{
 };
 
 fn main() {
+    setup_terminal();
     let args = Args::parse();
     let verbosity = args.get_verbosity();
     if let Commands::Slug { text } = args.command {
@@ -217,4 +218,14 @@ fn main() {
             // This was attended above in the code
         }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn setup_terminal() {
+    control::set_virtual_terminal(true).unwrap();
+}
+
+#[cfg(not(target_os = "windows"))]
+fn setup_terminal() {
+    // nothing is needed in *nix systems
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ fn main() {
                 ignore_unauthorized,
                 progress,
                 no_slug,
+                offline,
                 threads,
             } => {
                 let regex = unwrap_filter_regex(tag_filter.as_deref());
@@ -141,6 +142,7 @@ fn main() {
                     ignore_unauthorized,
                     threads,
                     no_slug,
+                    offline,
                     tag_filter: regex,
                     verbosity: verbosity.clone(),
                     progress_verbosity: match progress {
@@ -178,12 +180,14 @@ fn main() {
             ignore_unauthorized,
             progress,
             no_slug,
+            offline,
             threads,
         } => {
             let regex = unwrap_filter_regex(tag_filter.as_deref());
             let replace_tag = tag.map(|tag| ReplaceTag {
                 tag,
                 ignore_unauthorized,
+                offline,
                 threads,
                 no_slug,
                 tag_filter: regex,

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,28 +128,28 @@ fn main() {
             }
             Objects::Images {
                 filter,
-                remote_tag,
+                tag,
                 tag_filter,
                 ignore_unauthorized,
-                remote_progress,
+                progress,
                 no_slug,
                 threads,
             } => {
-                let tag = unwrap_filter_tag(filter.as_deref());
                 let regex = unwrap_filter_regex(tag_filter.as_deref());
-                let remote_tag = remote_tag.map(|tag| ReplaceTag {
+                let replace_tag = tag.map(|tag| ReplaceTag {
+                    tag,
                     ignore_unauthorized,
                     threads,
                     no_slug,
-                    remote_tag: tag,
                     tag_filter: regex,
                     verbosity: verbosity.clone(),
-                    remote_progress_verbosity: match remote_progress {
+                    progress_verbosity: match progress {
                         true => Verbosity::Verbose,
                         false => Verbosity::Quiet,
                     },
                 });
-                let op = compose.get_images(tag, remote_tag.as_ref());
+                let filter_by_tag = unwrap_filter_tag(filter.as_deref());
+                let op = compose.get_images(filter_by_tag, replace_tag.as_ref());
                 match op {
                     None => {
                         eprintln!("{}: No services section found", "ERROR".red());
@@ -173,28 +173,28 @@ fn main() {
         },
         Commands::Config {
             output,
-            remote_tag,
+            tag,
             tag_filter,
             ignore_unauthorized,
-            remote_progress,
+            progress,
             no_slug,
             threads,
         } => {
             let regex = unwrap_filter_regex(tag_filter.as_deref());
-            let remote_tag = remote_tag.map(|tag| ReplaceTag {
+            let replace_tag = tag.map(|tag| ReplaceTag {
+                tag,
                 ignore_unauthorized,
                 threads,
                 no_slug,
-                remote_tag: tag,
                 tag_filter: regex,
                 verbosity: verbosity.clone(),
-                remote_progress_verbosity: match remote_progress {
+                progress_verbosity: match progress {
                     true => Verbosity::Verbose,
                     false => Verbosity::Quiet,
                 },
             });
-            if let Some(remote_t) = remote_tag {
-                compose.update_images_with_remote_tag(&remote_t);
+            if let Some(remote_t) = replace_tag {
+                compose.update_images_tag(&remote_t);
             }
             let result = compose.to_string().unwrap_or_else(|err| {
                 eprintln!("{}: {}", "ERROR".red(), err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,20 +129,20 @@ fn main() {
             Objects::Images {
                 filter,
                 remote_tag,
-                remote_tag_filter,
+                tag_filter,
                 ignore_unauthorized,
                 remote_progress,
                 no_slug,
                 threads,
             } => {
                 let tag = unwrap_filter_tag(filter.as_deref());
-                let regex = unwrap_filter_regex(remote_tag_filter.as_deref());
+                let regex = unwrap_filter_regex(tag_filter.as_deref());
                 let remote_tag = remote_tag.map(|tag| RemoteTag {
                     ignore_unauthorized,
                     threads,
                     no_slug,
                     remote_tag: tag,
-                    remote_tag_filter: regex,
+                    tag_filter: regex,
                     verbosity: verbosity.clone(),
                     remote_progress_verbosity: match remote_progress {
                         true => Verbosity::Verbose,
@@ -174,19 +174,19 @@ fn main() {
         Commands::Config {
             output,
             remote_tag,
-            remote_tag_filter,
+            tag_filter,
             ignore_unauthorized,
             remote_progress,
             no_slug,
             threads,
         } => {
-            let regex = unwrap_filter_regex(remote_tag_filter.as_deref());
+            let regex = unwrap_filter_regex(tag_filter.as_deref());
             let remote_tag = remote_tag.map(|tag| RemoteTag {
                 ignore_unauthorized,
                 threads,
                 no_slug,
                 remote_tag: tag,
-                remote_tag_filter: regex,
+                tag_filter: regex,
                 verbosity: verbosity.clone(),
                 remote_progress_verbosity: match remote_progress {
                     true => Verbosity::Verbose,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -22,19 +22,20 @@ pub struct ComposeYaml {
 
 #[derive(Clone)]
 pub struct ReplaceTag {
-    /// replace tag with remote tag if exists
-    pub remote_tag: String,
-    /// don't replace with remote tag unless this regex match the image name / tag,
+    /// replace tag with local or remote tag if exists
+    pub tag: String,
+    /// don't replace with tag unless this regex matches the image name / tag,
     /// in case the bool is false, the replacing is done if the regex doesn't match
     pub tag_filter: Option<(Regex, bool)>,
-    /// docker may require to be logged-in to fetch some images info
+    /// docker may require to be logged-in to fetch some images info, with
+    /// `true` unauthorized errors are ignored
     pub ignore_unauthorized: bool,
-    /// Don't slugify the value from remote_tag.
+    /// Don't slugify the value from tag.
     pub no_slug: bool,
     /// verbosity used when fetching remote images info
     pub verbosity: Verbosity,
-    /// show remote tags found while they are fetched
-    pub remote_progress_verbosity: Verbosity,
+    /// show tags found while they are fetched
+    pub progress_verbosity: Verbosity,
     /// max number of threads used to fetch remote images info
     pub threads: u8,
 }
@@ -42,8 +43,8 @@ pub struct ReplaceTag {
 impl ReplaceTag {
     pub fn get_remote_tag(&self) -> String {
         match self.no_slug {
-            true => self.remote_tag.clone(),
-            false => get_slug(&self.remote_tag),
+            true => self.tag.clone(),
+            false => get_slug(&self.tag),
         }
     }
 }
@@ -94,7 +95,7 @@ impl ComposeYaml {
     pub fn get_images(
         &self,
         filter_by_tag: Option<&str>,
-        remote_tag: Option<&ReplaceTag>,
+        tag: Option<&ReplaceTag>,
     ) -> Option<Vec<String>> {
         let services = self.get_services()?;
         let mut images = services
@@ -117,9 +118,9 @@ impl ComposeYaml {
             .collect::<Vec<_>>();
         images.sort();
         images.dedup();
-        if let Some(remote) = remote_tag {
-            let show_remote_progress = matches!(remote.verbosity, Verbosity::Verbose)
-                || matches!(remote.remote_progress_verbosity, Verbosity::Verbose);
+        if let Some(replace_tag) = tag {
+            let show_progress = matches!(replace_tag.verbosity, Verbosity::Verbose)
+                || matches!(replace_tag.progress_verbosity, Verbosity::Verbose);
             let input = Arc::new(Mutex::new(
                 images
                     .iter()
@@ -127,12 +128,12 @@ impl ComposeYaml {
                     .map(|e| e.to_string())
                     .collect::<Vec<String>>(),
             ));
-            let remote_arc = Arc::new(remote.clone());
+            let replace_arc = Arc::new(replace_tag.clone());
             let mut updated_images: Vec<String> = Vec::with_capacity(images.len());
             let (tx, rx): (Sender<String>, Receiver<String>) = mpsc::channel();
             let mut thread_children = Vec::new();
-            let nthreads = max(1, min(images.len(), remote.threads as usize));
-            if matches!(remote.verbosity, Verbosity::Verbose) {
+            let nthreads = max(1, min(images.len(), replace_tag.threads as usize));
+            if matches!(replace_tag.verbosity, Verbosity::Verbose) {
                 eprintln!(
                     "{}: spawning {} threads to fetch remote info from {} images",
                     "DEBUG".green(),
@@ -142,7 +143,7 @@ impl ComposeYaml {
             }
             for _ in 0..nthreads {
                 let input = Arc::clone(&input);
-                let remote = Arc::clone(&remote_arc);
+                let replace = Arc::clone(&replace_arc);
                 let thread_tx = tx.clone();
                 let child = thread::spawn(move || {
                     loop {
@@ -153,8 +154,8 @@ impl ComposeYaml {
                             let image_parts = image.split(':').collect::<Vec<_>>();
                             let image_name = *image_parts.first().unwrap();
                             let remote_image =
-                                format!("{}:{}", image_name, remote.get_remote_tag());
-                            if remote
+                                format!("{}:{}", image_name, replace.get_remote_tag());
+                            if replace
                                 .tag_filter
                                 .as_ref()
                                 .map(|r| (r.1, r.0.is_match(&image)))
@@ -164,20 +165,26 @@ impl ComposeYaml {
                                 })
                                 .unwrap_or(true)
                             {
-                                // check whether the image:<remote_tag> exists or not
-                                match Self::has_manifest(
-                                    &remote,
-                                    &remote_image,
-                                    show_remote_progress,
-                                ) {
+                                // check whether the image:<tag> exists or not locally
+                                match Self::has_image(&replace, &remote_image, show_progress) {
                                     true => thread_tx.send(remote_image).unwrap(),
-                                    false => thread_tx.send(image).unwrap(),
+                                    false => {
+                                        // if not exists locally, check remote registry
+                                        match Self::has_manifest(
+                                            &replace,
+                                            &remote_image,
+                                            show_progress,
+                                        ) {
+                                            true => thread_tx.send(remote_image).unwrap(),
+                                            false => thread_tx.send(image).unwrap(),
+                                        }
+                                    }
                                 }
                             } else {
                                 // skip the remote check and add it as it is into the list
-                                if show_remote_progress {
+                                if show_progress {
                                     eprintln!(
-                                        "{}: remote manifest for image {} ... {} ",
+                                        "{}: manifest for image {} ... {} ",
                                         "DEBUG".green(),
                                         image_name.yellow(),
                                         "skipped".bright_black()
@@ -211,11 +218,60 @@ impl ComposeYaml {
         Some(images.iter().map(|i| i.to_string()).collect::<Vec<_>>())
     }
 
-    /// Returns whether the manifest, handling possible errors.
+    /// Returns whether the image exists locally, handling possible errors.
+    /// When the image exists, means the image exists for the
+    /// particular tag passed in the local registry.
+    fn has_image(replace_tag: &ReplaceTag, remote_image: &str, show_progress: bool) -> bool {
+        let command = DockerCommand::new(replace_tag.verbosity.clone());
+        let inspect_output = command.get_image_inspect(remote_image).unwrap_or_else(|e| {
+            eprintln!(
+                "{}: fetching image manifest locally for {}: {}",
+                "ERROR".red(),
+                remote_image,
+                e
+            );
+            process::exit(151);
+        });
+        if inspect_output.status.success() {
+            if show_progress {
+                eprintln!(
+                    "{}: manifest for image {} ... {} ",
+                    "DEBUG".green(),
+                    remote_image.yellow(),
+                    "found".green()
+                );
+            }
+            true
+        } else {
+            let exit_code = command.exit_code(&inspect_output);
+            let stderr = String::from_utf8(inspect_output.stderr).unwrap();
+            if stderr.to_lowercase().contains("no such image") {
+                // if show_progress {
+                //     eprintln!(
+                //         "{}: local image {} ... {} ",
+                //         "DEBUG".green(),
+                //         remote_image.yellow(),
+                //         "not found".purple()
+                //     );
+                // }
+                false
+            } else {
+                eprintln!(
+                    "{}: fetching local image manifest for {}: {}",
+                    "ERROR".red(),
+                    remote_image,
+                    stderr
+                );
+                process::exit(exit_code);
+            }
+        }
+    }
+
+    /// Returns whether the manifest exists, handling possible errors.
     /// When the manifest exists, means the image exists for the
     /// particular tag passed in the remote registry.
-    fn has_manifest(remote: &ReplaceTag, remote_image: &str, show_remote_progress: bool) -> bool {
-        let command = DockerCommand::new(remote.verbosity.clone());
+    fn has_manifest(replace_tag: &ReplaceTag, remote_image: &str, show_progress: bool) -> bool {
+        let command = DockerCommand::new(replace_tag.verbosity.clone());
         let inspect_output = command
             .get_manifest_inspect(remote_image)
             .unwrap_or_else(|e| {
@@ -228,9 +284,9 @@ impl ComposeYaml {
                 process::exit(151);
             });
         if inspect_output.status.success() {
-            if show_remote_progress {
+            if show_progress {
                 eprintln!(
-                    "{}: remote manifest for image {} ... {} ",
+                    "{}: manifest for image {} ... {} ",
                     "DEBUG".green(),
                     remote_image.yellow(),
                     "found".green()
@@ -240,12 +296,12 @@ impl ComposeYaml {
         } else {
             let exit_code = command.exit_code(&inspect_output);
             let stderr = String::from_utf8(inspect_output.stderr).unwrap();
-            if stderr.contains("no such manifest")
-                || (remote.ignore_unauthorized && stderr.contains("unauthorized:"))
+            if stderr.to_lowercase().contains("no such manifest")
+                || (replace_tag.ignore_unauthorized && stderr.contains("unauthorized:"))
             {
-                if show_remote_progress {
+                if show_progress {
                     eprintln!(
-                        "{}: remote manifest for image {} ... {} ",
+                        "{}: manifest for image {} ... {} ",
                         "DEBUG".green(),
                         remote_image.yellow(),
                         "not found".purple()
@@ -264,11 +320,11 @@ impl ComposeYaml {
         }
     }
 
-    /// Update all services' image attributes with the remote
-    /// tag passed if the tag exists in the remote registry, otherwise
+    /// Update all services' image attributes with the tag passed if the
+    /// tag exists locally or in the remote registry, otherwise
     /// the image value is untouched.
-    pub fn update_images_with_remote_tag(&mut self, remote_tag: &ReplaceTag) {
-        if let Some(images_with_remote) = self.get_images(None, Some(remote_tag)) {
+    pub fn update_images_tag(&mut self, replace_tag: &ReplaceTag) {
+        if let Some(images_with_remote) = self.get_images(None, Some(replace_tag)) {
             let services_names = self
                 .get_root_element_names("services")
                 .iter()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,7 @@ pub struct RemoteTag {
     pub remote_tag: String,
     /// don't replace with remote tag unless this regex match the image name / tag,
     /// in case the bool is false, the replacing is done if the regex doesn't match
-    pub remote_tag_filter: Option<(Regex, bool)>,
+    pub tag_filter: Option<(Regex, bool)>,
     /// docker may require to be logged-in to fetch some images info
     pub ignore_unauthorized: bool,
     /// Don't slugify the value from remote_tag.
@@ -155,7 +155,7 @@ impl ComposeYaml {
                             let remote_image =
                                 format!("{}:{}", image_name, remote.get_remote_tag());
                             if remote
-                                .remote_tag_filter
+                                .tag_filter
                                 .as_ref()
                                 .map(|r| (r.1, r.0.is_match(&image)))
                                 .map(|(affirmative_expr, is_match)| {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -21,7 +21,7 @@ pub struct ComposeYaml {
 }
 
 #[derive(Clone)]
-pub struct RemoteTag {
+pub struct ReplaceTag {
     /// replace tag with remote tag if exists
     pub remote_tag: String,
     /// don't replace with remote tag unless this regex match the image name / tag,
@@ -39,7 +39,7 @@ pub struct RemoteTag {
     pub threads: u8,
 }
 
-impl RemoteTag {
+impl ReplaceTag {
     pub fn get_remote_tag(&self) -> String {
         match self.no_slug {
             true => self.remote_tag.clone(),
@@ -94,7 +94,7 @@ impl ComposeYaml {
     pub fn get_images(
         &self,
         filter_by_tag: Option<&str>,
-        remote_tag: Option<&RemoteTag>,
+        remote_tag: Option<&ReplaceTag>,
     ) -> Option<Vec<String>> {
         let services = self.get_services()?;
         let mut images = services
@@ -214,7 +214,7 @@ impl ComposeYaml {
     /// Returns whether the manifest, handling possible errors.
     /// When the manifest exists, means the image exists for the
     /// particular tag passed in the remote registry.
-    fn has_manifest(remote: &RemoteTag, remote_image: &str, show_remote_progress: bool) -> bool {
+    fn has_manifest(remote: &ReplaceTag, remote_image: &str, show_remote_progress: bool) -> bool {
         let command = DockerCommand::new(remote.verbosity.clone());
         let inspect_output = command
             .get_manifest_inspect(remote_image)
@@ -267,7 +267,7 @@ impl ComposeYaml {
     /// Update all services' image attributes with the remote
     /// tag passed if the tag exists in the remote registry, otherwise
     /// the image value is untouched.
-    pub fn update_images_with_remote_tag(&mut self, remote_tag: &RemoteTag) {
+    pub fn update_images_with_remote_tag(&mut self, remote_tag: &ReplaceTag) {
         if let Some(images_with_remote) = self.get_images(None, Some(remote_tag)) {
             let services_names = self
                 .get_root_element_names("services")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub fn get_yml_content(filename: Option<&str>, verbosity: Verbosity) -> String {
     let filename = get_compose_filename(filename, verbosity).unwrap_or_else(|err| {
         eprintln!("{}: {}", "ERROR".red(), err);
         if err.contains("no such file or directory") {
-            process::exit(14);
+            process::exit(1);
         }
         process::exit(10);
     });

--- a/tests/docker_test.rs
+++ b/tests/docker_test.rs
@@ -73,8 +73,11 @@ fn run_docker_config_multiple_files() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // VAR=val was turned into VAR: val
-    assert!(stdout.contains("POSTGRES_PASSWORD: password"));
+    // VAR=val may be turned into VAR: val depending on the docker compose version
+    assert!(
+        stdout.contains("POSTGRES_PASSWORD: password")
+            || stdout.contains("POSTGRES_PASSWORD=password")
+    );
     assert!(stdout.contains("image: nginx"));
 }
 

--- a/tests/docker_test.rs
+++ b/tests/docker_test.rs
@@ -27,7 +27,7 @@ fn run_docker_compose_version() {
 
 #[test]
 #[serial]
-#[ignore] // cuase issues in CI so disabled for now
+#[ignore] // because issues in CI so disabled for now
 fn run_missed_docker() {
     env::set_var("DOCKER_BIN", "docker1234");
     let command = DockerCommand::new(Verbosity::default());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 /// The following tests are all marked as "ignore" to not delay tests execution,
 /// but running the tests with the `--ignored` flag will make them to be executed,
 /// (or use `make test-integration`).
-use docker_pose::{ComposeYaml, RemoteTag, Verbosity};
+use docker_pose::{ComposeYaml, ReplaceTag, Verbosity};
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use serde_yaml::Error;
@@ -21,7 +21,7 @@ services:
     image: rabbitmq:3
     ";
     let compose = ComposeYaml::new(&yaml)?;
-    let remote_tag = RemoteTag {
+    let remote_tag = ReplaceTag {
         remote_tag: "16.2".to_string(),
         tag_filter: None,
         ignore_unauthorized: true,
@@ -53,7 +53,7 @@ services:
     image: mysql:7
     ";
     let compose = ComposeYaml::new(&yaml)?;
-    let remote_tag = RemoteTag {
+    let remote_tag = ReplaceTag {
         remote_tag: "8".to_string(),
         tag_filter: Some((Regex::new(r"mysql").unwrap(), true)),
         ignore_unauthorized: true,
@@ -95,7 +95,7 @@ services:
   rabbitmq:
     image: rabbitmq
     "#;
-    let remote_tag = RemoteTag {
+    let remote_tag = ReplaceTag {
         remote_tag: "8 ".to_string(), // the white space will be trimmed when slug is used
         // Exclude postgres
         tag_filter: Some((Regex::new(r"postgres").unwrap(), false)),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,7 +23,7 @@ services:
     let compose = ComposeYaml::new(&yaml)?;
     let remote_tag = RemoteTag {
         remote_tag: "16.2".to_string(),
-        remote_tag_filter: None,
+        tag_filter: None,
         ignore_unauthorized: true,
         no_slug: false,
         verbosity: Verbosity::default(),
@@ -55,7 +55,7 @@ services:
     let compose = ComposeYaml::new(&yaml)?;
     let remote_tag = RemoteTag {
         remote_tag: "8".to_string(),
-        remote_tag_filter: Some((Regex::new(r"mysql").unwrap(), true)),
+        tag_filter: Some((Regex::new(r"mysql").unwrap(), true)),
         ignore_unauthorized: true,
         no_slug: false,
         verbosity: Verbosity::default(),
@@ -98,7 +98,7 @@ services:
     let remote_tag = RemoteTag {
         remote_tag: "8 ".to_string(), // the white space will be trimmed when slug is used
         // Exclude postgres
-        remote_tag_filter: Some((Regex::new(r"postgres").unwrap(), false)),
+        tag_filter: Some((Regex::new(r"postgres").unwrap(), false)),
         ignore_unauthorized: true,
         no_slug: false,
         verbosity: Verbosity::default(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,16 +21,16 @@ services:
     image: rabbitmq:3
     ";
     let compose = ComposeYaml::new(&yaml)?;
-    let remote_tag = ReplaceTag {
-        remote_tag: "16.2".to_string(),
+    let replace_tag = ReplaceTag {
+        tag: "16.2".to_string(),
         tag_filter: None,
         ignore_unauthorized: true,
         no_slug: false,
         verbosity: Verbosity::default(),
-        remote_progress_verbosity: Verbosity::Quiet,
+        progress_verbosity: Verbosity::Quiet,
         threads: 4,
     };
-    let images = compose.get_images(None, Some(&remote_tag));
+    let images = compose.get_images(None, Some(&replace_tag));
     assert_eq!(
         images,
         Some(vec![
@@ -53,16 +53,16 @@ services:
     image: mysql:7
     ";
     let compose = ComposeYaml::new(&yaml)?;
-    let remote_tag = ReplaceTag {
-        remote_tag: "8".to_string(),
+    let replace_tag = ReplaceTag {
+        tag: "8".to_string(),
         tag_filter: Some((Regex::new(r"mysql").unwrap(), true)),
         ignore_unauthorized: true,
         no_slug: false,
         verbosity: Verbosity::default(),
-        remote_progress_verbosity: Verbosity::Quiet,
+        progress_verbosity: Verbosity::Quiet,
         threads: 2,
     };
-    let images = compose.get_images(None, Some(&remote_tag));
+    let images = compose.get_images(None, Some(&replace_tag));
     assert_eq!(
         images,
         Some(vec![
@@ -95,18 +95,18 @@ services:
   rabbitmq:
     image: rabbitmq
     "#;
-    let remote_tag = ReplaceTag {
-        remote_tag: "8 ".to_string(), // the white space will be trimmed when slug is used
+    let replace_tag = ReplaceTag {
+        tag: "8 ".to_string(), // the white space will be trimmed when slug is used
         // Exclude postgres
         tag_filter: Some((Regex::new(r"postgres").unwrap(), false)),
         ignore_unauthorized: true,
         no_slug: false,
         verbosity: Verbosity::default(),
-        remote_progress_verbosity: Verbosity::Quiet,
+        progress_verbosity: Verbosity::Quiet,
         threads: 2,
     };
     let mut compose = ComposeYaml::new(&yaml)?;
-    compose.update_images_with_remote_tag(&remote_tag);
+    compose.update_images_tag(&replace_tag);
     let new_yaml = compose.to_string();
     assert!(new_yaml.is_ok());
     assert_eq!(expected_yaml.to_string().trim(), new_yaml.unwrap().trim());

--- a/tests/run_integration_test.bats
+++ b/tests/run_integration_test.bats
@@ -5,18 +5,18 @@ setup() {
 
 @test "can list images with remote tag" {
     run target/debug/pose --verbose -f tests/compose-remote-check.yaml \
-        list images --remote-tag 3.1.1 --tag-filter "regex=mrsarm/"
+        list images --tag 3.1.1 --tag-filter "regex=mrsarm/"
     assert_success
     assert_output --partial "DEBUG: docker compose -f tests/compose-remote-check.yaml config"
     # django-mongotail:3.1.1 is checked, and it's found
     assert_output --partial "DEBUG: docker manifest inspect --insecure mrsarm/mongotail:3.1.1"
-    assert_output --partial "DEBUG: remote manifest for image mrsarm/mongotail:3.1.1 ... found"
+    assert_output --partial "DEBUG: manifest for image mrsarm/mongotail:3.1.1 ... found"
     # django-coleman:3.1.1 is checked, although it doesn't exist in the docker registry
     assert_output --partial "DEBUG: docker manifest inspect --insecure mrsarm/django-coleman:3.1.1"
-    refute_output --partial "DEBUG: remote manifest for image mrsarm/django-coleman:3.1.1 ... found"
+    refute_output --partial "DEBUG: manifest for image mrsarm/django-coleman:3.1.1 ... found"
     # bitnami/kafka:3.1.1 exists, but is NOT checked because the filter
     refute_output --partial "DEBUG: docker manifest inspect --insecure bitnami/kafka:3.1.1"
-    assert_output --partial "DEBUG: remote manifest for image bitnami/kafka ... skipped"
+    assert_output --partial "DEBUG: manifest for image bitnami/kafka ... skipped"
 
     # Output
     assert_output --partial "bitnami/kafka:3.0"
@@ -27,18 +27,18 @@ setup() {
 
 @test "can output config with remote tag" {
     run target/debug/pose --verbose -f tests/compose-remote-check.yaml --no-normalize \
-        config --remote-tag 3.1.1 --tag-filter "regex=mrsarm/"
+        config --tag 3.1.1 --tag-filter "regex=mrsarm/"
     assert_success
     assert_output --partial "DEBUG: docker compose -f tests/compose-remote-check.yaml config"
     # django-mongotail:3.1.1 is checked, and it's found
     assert_output --partial "DEBUG: docker manifest inspect --insecure mrsarm/mongotail:3.1.1"
-    assert_output --partial "DEBUG: remote manifest for image mrsarm/mongotail:3.1.1 ... found"
+    assert_output --partial "DEBUG: manifest for image mrsarm/mongotail:3.1.1 ... found"
     # django-coleman:3.1.1 is checked, although it doesn't exist in the docker registry
     assert_output --partial "DEBUG: docker manifest inspect --insecure mrsarm/django-coleman:3.1.1"
-    assert_output --partial "DEBUG: remote manifest for image mrsarm/django-coleman:3.1.1 ... not found"
+    assert_output --partial "DEBUG: manifest for image mrsarm/django-coleman:3.1.1 ... not found"
     # bitnami/kafka:3.1.1 exists, but is NOT checked because the filter
     refute_output --partial "DEBUG: docker manifest inspect --insecure bitnami/kafka:3.1.1"
-    assert_output --partial "DEBUG: remote manifest for image bitnami/kafka ... skipped"
+    assert_output --partial "DEBUG: manifest for image bitnami/kafka ... skipped"
 
     # Output
     assert_output --partial "image: bitnami/kafka:3.0"

--- a/tests/run_integration_test.bats
+++ b/tests/run_integration_test.bats
@@ -5,7 +5,7 @@ setup() {
 
 @test "can list images with remote tag" {
     run target/debug/pose --verbose -f tests/compose-remote-check.yaml \
-        list images --remote-tag 3.1.1 --remote-tag-filter "regex=mrsarm/"
+        list images --remote-tag 3.1.1 --tag-filter "regex=mrsarm/"
     assert_success
     assert_output --partial "DEBUG: docker compose -f tests/compose-remote-check.yaml config"
     # django-mongotail:3.1.1 is checked, and it's found
@@ -27,7 +27,7 @@ setup() {
 
 @test "can output config with remote tag" {
     run target/debug/pose --verbose -f tests/compose-remote-check.yaml --no-normalize \
-        config --remote-tag 3.1.1 --remote-tag-filter "regex=mrsarm/"
+        config --remote-tag 3.1.1 --tag-filter "regex=mrsarm/"
     assert_success
     assert_output --partial "DEBUG: docker compose -f tests/compose-remote-check.yaml config"
     # django-mongotail:3.1.1 is checked, and it's found

--- a/tests/run_test.bats
+++ b/tests/run_test.bats
@@ -112,19 +112,20 @@ setup() {
 
 @test "can detect file does not exist" {
     run target/debug/pose -f does-not-exist.yaml list services
-    assert_failure 14
+    # failure from docker compose can be either 14 (old versions) or 1
+    assert_failure
     assert_output --partial "does-not-exist.yaml: no such file or directory"
 }
 
 @test "can detect file does not exist without docker" {
     run target/debug/pose --no-docker -f does-not-exist.yaml list services
-    assert_failure 14
+    assert_failure 1
     assert_output --partial "does-not-exist.yaml: no such file or directory"
 }
 
 @test "can detect invalid file" {
     run target/debug/pose -f Makefile list services
-    assert_failure 15
+    assert_failure
     assert_output --partial "ERROR: calling compose"
     assert_output --partial "yaml:"
 }
@@ -143,9 +144,6 @@ setup() {
     assert_output --partial "app2"
     assert_output --partial "postgres"
     refute_output --partial "nginx"
-    # Secrets are filter out by docker compose config
-    # because are not used in the example
-    refute_output --partial "secrets"
 }
 
 @test "can output config without docker" {


### PR DESCRIPTION
- When replacing tags check local registry first.
- Argument `--offline` to only check tags locally.
- Remove prefix `--remote` to tag replacement arguments, e.g. `--remote-tag` → `--tag`.
- Validate no empty arguments.
- Fix terminal colors output on Windows.
- Fix tests: newer version of docker compose return different outputs.
- CI: avoid duplication of runners in GitHub Actions.