### PR TITLE
v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,10 +72,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -143,6 +161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +190,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "docker-pose"
-version = "0.4.0-b4"
+version = "0.4.0-b5"
 dependencies = [
  "clap",
  "clap-num",
@@ -174,6 +201,8 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "strum_macros",
+ "ureq",
+ "url",
 ]
 
 [[package]]
@@ -181,6 +210,25 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -260,6 +308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +335,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -328,6 +397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +442,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.1",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -442,6 +526,52 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -535,6 +665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,10 +707,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -577,10 +749,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "windows-sys"
@@ -719,3 +940,9 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ serial_test = "3.0"
 
 [profile.release]
 # This is going to be the default soon if not provided
-strip = "debuginfo"
+opt-level = "s"
+strip = "symbols"
 
 [[bin]]
 name = "pose"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-pose"
-version = "0.4.0-b4"
+version = "0.4.0-b5"
 edition = "2021"
 authors = ["Mariano Ruiz <mrsarm@gmail.com>"]
 description = "Command line tool to play with 🐳 Docker Compose files."
@@ -11,13 +11,15 @@ repository = "https://github.com/mrsarm/pose"
 categories = ["docker", "command-line-interface"]
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "cargo"] }
 clap-num = "1.1"
 colored = "2.1"
 lazy_static = "1.4"
 serde_yaml = "0.9"
 strum_macros = "0.26"
 regex = "1.10"
+ureq = "2.9"
+url = "2.5"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,6 @@
 /// Types to parse the command line arguments with the clap crate.
-use crate::Verbosity;
+use crate::{positive_less_than_32, string_no_empty, string_script, Verbosity};
 use clap::{Parser, Subcommand, ValueEnum};
-use clap_num::number_range;
 use std::cmp::Ord;
 
 #[derive(Parser)]
@@ -40,17 +39,6 @@ impl Args {
             },
         }
     }
-}
-
-fn positive_less_than_32(s: &str) -> Result<u8, String> {
-    number_range(s, 1, 32)
-}
-
-fn string_no_empty(s: &str) -> Result<String, String> {
-    if s.is_empty() {
-        return Err("must be at least 1 character long".to_string());
-    }
-    Ok(s.to_string())
 }
 
 #[derive(Subcommand)]
@@ -108,12 +96,14 @@ pub enum Commands {
     },
 
     /// Download a file from an HTTP URL, if the resource doesn't exist, fallback
-    /// to another URL provided or generated replacing from the URL given part
-    /// of the path.
+    /// to another URL generated editing the URL given with a script provided in the
+    /// form of "text-to-replace:replacer".
     Get {
         #[arg(value_parser = string_no_empty)]
         url: String,
-        // TODO add replacer (check sed) and headers arguments
+        #[arg(value_parser = string_script)]
+        script: Option<(String, String)>,
+        // TODO add headers and progress arguments
         /// Save to file (default use the same filename set in the url)
         #[arg(short, long, value_name = "FILE")]
         output: Option<String>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -103,7 +103,6 @@ pub enum Commands {
         url: String,
         #[arg(value_parser = string_script)]
         script: Option<(String, String)>,
-        // TODO add headers and progress arguments
         /// Save to file (default use the same filename set in the url)
         #[arg(short, long, value_name = "FILE")]
         output: Option<String>,
@@ -115,6 +114,7 @@ pub enum Commands {
         /// Maximum time in seconds that you allow the whole operation to take.
         #[arg(short, long, value_name = "SECONDS", default_value_t = 300)]
         max_time: u16,
+        // TODO add headers argument, and integration tests
     },
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -106,6 +106,15 @@ pub enum Commands {
         #[arg(value_parser = string_no_empty)]
         text: Option<String>,
     },
+
+    /// Download a file from an HTTP URL, if the resource doesn't exist, fallback
+    /// to another URL provided or generated replacing from the URL given part
+    /// of the path.
+    Get {
+        #[arg(value_parser = string_no_empty)]
+        url: String,
+        // TODO add replacer (check sed), timeout, output and headers arguments
+    },
 }
 
 #[derive(Subcommand, strum_macros::Display, PartialEq)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
 /// Types to parse the command line arguments with the clap crate.
-use crate::{positive_less_than_32, string_no_empty, string_script, Verbosity};
+use crate::{header, positive_less_than_32, string_no_empty, string_script, Verbosity};
 use clap::{Parser, Subcommand, ValueEnum};
 use std::cmp::Ord;
 
@@ -114,7 +114,9 @@ pub enum Commands {
         /// Maximum time in seconds that you allow the whole operation to take.
         #[arg(short, long, value_name = "SECONDS", default_value_t = 300)]
         max_time: u16,
-        // TODO add headers argument, and integration tests
+        /// HTTP header to include in the request
+        #[arg(short = 'H', long = "header", value_name = "HEADER", value_parser = header)]
+        headers: Vec<(String, String)>,
     },
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -113,7 +113,10 @@ pub enum Commands {
     Get {
         #[arg(value_parser = string_no_empty)]
         url: String,
-        // TODO add replacer (check sed), timeout, output and headers arguments
+        // TODO add replacer (check sed), timeout and headers arguments
+        /// Save to file (default use the same filename set in the url)
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<String>,
     },
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -113,10 +113,18 @@ pub enum Commands {
     Get {
         #[arg(value_parser = string_no_empty)]
         url: String,
-        // TODO add replacer (check sed), timeout and headers arguments
+        // TODO add replacer (check sed) and headers arguments
         /// Save to file (default use the same filename set in the url)
         #[arg(short, long, value_name = "FILE")]
         output: Option<String>,
+        /// Maximum time in seconds that you allow pose's connection to take.
+        /// This only limits the connection phase, so if pose connects within the
+        /// given period it will continue, if not it will exit with error.
+        #[arg(long, value_name = "SECONDS", default_value_t = 30)]
+        timeout_connect: u16,
+        /// Maximum time in seconds that you allow the whole operation to take.
+        #[arg(short, long, value_name = "SECONDS", default_value_t = 300)]
+        max_time: u16,
     },
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -99,8 +99,15 @@ pub enum Commands {
     /// to another URL generated editing the URL given with a script provided in the
     /// form of "text-to-replace:replacer".
     Get {
+        /// The URL where the file is located
         #[arg(value_parser = string_no_empty)]
         url: String,
+        /// if request to URL responds back with HTTP 404, create a second URL
+        /// replacing any occurrence of the left part of the script with the right
+        /// part. Each part of the script has to be separated with the symbol `:`.
+        /// E.g. `pose get https://server.com/repo/master/compose.yml master:feature-a`
+        /// will try first download the resource from https://server.com/repo/master/compose.yml,
+        /// if not found, will try at https://server.com/repo/feature-a/compose.yml
         #[arg(value_parser = string_script)]
         script: Option<(String, String)>,
         /// Save to file (default use the same filename set in the url)

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,73 @@
+use clap::crate_version;
+use colored::Colorize;
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+use std::{io, process};
+use ureq::{Agent, AgentBuilder, Error};
+use url::Url;
+
+pub fn get(url: &str) {
+    let parsed_url = match Url::parse(url) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{}: invalid URL - {}", "ERROR".red(), e);
+            process::exit(3);
+        }
+    };
+    let path = if parsed_url.path() == "/" {
+        eprintln!(
+            "{}: URL without filename, you have to provide \
+            the filename where to store the file with the argument {}",
+            "ERROR".red(),
+            "-o, --output".yellow()
+        );
+        process::exit(4); // TODO add -o argument
+    } else {
+        parsed_url.path()
+    };
+    let path = Path::new(path);
+    let filename = path.file_name().unwrap().to_str().unwrap();
+    let agent: Agent = AgentBuilder::new()
+        .timeout(Duration::from_secs(5)) // TODO add timeout argument
+        .user_agent(format!("pose/{}", crate_version!()).as_str())
+        .build();
+    match agent.get(url).call() {
+        Ok(resp) => {
+            let mut content = resp.into_reader();
+            let mut file = File::create(filename).unwrap_or_else(|e| {
+                eprintln!(
+                    "{}: creating file '{}' - {}",
+                    "ERROR".red(),
+                    filename.yellow(),
+                    e
+                );
+                process::exit(5);
+            });
+            io::copy(&mut content, &mut file).unwrap_or_else(|e| {
+                eprintln!(
+                    "{}: writing output to file '{}': {}",
+                    "ERROR".red(),
+                    filename.yellow(),
+                    e
+                );
+                process::exit(6);
+            });
+        }
+        Err(Error::Status(code, response)) => {
+            eprintln!(
+                "{}: {} {} {}",
+                "ERROR".red(),
+                response.http_version(),
+                code,
+                response.status_text()
+            );
+            eprintln!("{}", response.into_string().unwrap_or("".to_string()));
+            process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("{}: {}", "ERROR".red(), e);
+            process::exit(2);
+        }
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -104,6 +104,9 @@ fn _get_and_save(
             }
         }
         Err(e) => {
+            if !matches!(verbosity, Verbosity::Quiet) {
+                eprintln!("{}", "failed".red())
+            }
             eprintln!("{}: {}", "ERROR".red(), e);
             process::exit(7);
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -7,7 +7,7 @@ use std::{io, process};
 use ureq::{Agent, AgentBuilder, Error};
 use url::Url;
 
-pub fn get_and_save(url: &str, output: Option<&str>) {
+pub fn get_and_save(url: &str, output: Option<&str>, timeout_connect_secs: u16, max_time: u16) {
     let parsed_url = match Url::parse(url) {
         Ok(r) => r,
         Err(e) => {
@@ -30,7 +30,8 @@ pub fn get_and_save(url: &str, output: Option<&str>) {
     };
     let path = Path::new(path);
     let agent: Agent = AgentBuilder::new()
-        .timeout(Duration::from_secs(5)) // TODO add timeout argument
+        .timeout_connect(Duration::from_secs(timeout_connect_secs.into()))
+        .timeout(Duration::from_secs(max_time.into()))
         .user_agent(format!("pose/{}", crate_version!()).as_str())
         .build();
     match agent.get(url).call() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub use docker::DockerCommand;
 pub use git::GitCommand;
 pub use http::get_and_save;
 pub use parse::{
-    get_compose_filename, positive_less_than_32, string_no_empty, string_script, ComposeYaml,
-    ReplaceTag,
+    get_compose_filename, header, positive_less_than_32, string_no_empty, string_script,
+    ComposeYaml, ReplaceTag,
 };
 pub use utils::{
     get_service, get_slug, get_yml_content, print_names, unwrap_filter_regex, unwrap_filter_tag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod args;
 mod cmd;
 mod docker;
 mod git;
+mod http;
 mod parse;
 mod utils;
 mod verbose;
@@ -16,6 +17,7 @@ pub use cmd::{
 };
 pub use docker::DockerCommand;
 pub use git::GitCommand;
+pub use http::get;
 pub use parse::{get_compose_filename, ComposeYaml, ReplaceTag};
 pub use utils::{
     get_service, get_slug, get_yml_content, print_names, unwrap_filter_regex, unwrap_filter_tag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,10 @@ pub use cmd::{
 pub use docker::DockerCommand;
 pub use git::GitCommand;
 pub use http::{get_and_save, replace_all};
-pub use parse::{get_compose_filename, ComposeYaml, ReplaceTag};
+pub use parse::{
+    get_compose_filename, positive_less_than_32, string_no_empty, string_script, ComposeYaml,
+    ReplaceTag,
+};
 pub use utils::{
     get_service, get_slug, get_yml_content, print_names, unwrap_filter_regex, unwrap_filter_tag,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use cmd::{
 };
 pub use docker::DockerCommand;
 pub use git::GitCommand;
-pub use http::get;
+pub use http::{get_and_save, replace_all};
 pub use parse::{get_compose_filename, ComposeYaml, ReplaceTag};
 pub use utils::{
     get_service, get_slug, get_yml_content, print_names, unwrap_filter_regex, unwrap_filter_tag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use cmd::{
 };
 pub use docker::DockerCommand;
 pub use git::GitCommand;
-pub use http::{get_and_save, replace_all};
+pub use http::get_and_save;
 pub use parse::{
     get_compose_filename, positive_less_than_32, string_no_empty, string_script, ComposeYaml,
     ReplaceTag,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ fn main() {
             }
         }
         process::exit(0)
+    } else if let Commands::Get { url, output } = args.command {
+        get_and_save(&url, output.as_deref());
+        process::exit(0)
     }
     if args.filenames.len() > 1 && args.no_docker {
         eprintln!(
@@ -217,11 +220,8 @@ fn main() {
                 println!("{}", result);
             }
         }
-        Commands::Slug { .. } => {
+        Commands::Slug { .. } | Commands::Get { .. } => {
             // This was attended above in the code
-        }
-        Commands::Get { url } => {
-            get_and_save(&url);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
         max_time,
     } = args.command
     {
-        get_and_save(&url, &script, &output, timeout_connect, max_time);
+        get_and_save(&url, &script, &output, timeout_connect, max_time, verbosity.clone());
         process::exit(0)
     }
     if args.filenames.len() > 1 && args.no_docker {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{fs, process};
 //mod lib;
 //use crate::lib::ComposeYaml;
 use docker_pose::{
-    cmd_get_success_output_or_fail, get_service, get_slug, get_yml_content, print_names,
+    cmd_get_success_output_or_fail, get, get_service, get_slug, get_yml_content, print_names,
     unwrap_filter_regex, unwrap_filter_tag, Args, Commands, ComposeYaml, DockerCommand, GitCommand,
     Objects, ReplaceTag, Verbosity,
 };
@@ -16,6 +16,7 @@ fn main() {
     setup_terminal();
     let args = Args::parse();
     let verbosity = args.get_verbosity();
+    // TODO check here Commands::Get to avoid compose parsing
     if let Commands::Slug { text } = args.command {
         if let Some(t) = text {
             println!("{}", get_slug(&t));
@@ -218,6 +219,9 @@ fn main() {
         }
         Commands::Slug { .. } => {
             // This was attended above in the code
+        }
+        Commands::Get { url } => {
+            get(&url);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
         output,
         timeout_connect,
         max_time,
+        headers,
     } = args.command
     {
         get_and_save(
@@ -57,6 +58,7 @@ fn main() {
             &output,
             timeout_connect,
             max_time,
+            &headers,
             verbosity.clone(),
         );
         process::exit(0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,12 +45,13 @@ fn main() {
         process::exit(0)
     } else if let Commands::Get {
         url,
+        script,
         output,
         timeout_connect,
         max_time,
     } = args.command
     {
-        get_and_save(&url, output.as_deref(), timeout_connect, max_time);
+        get_and_save(&url, &script, &output, timeout_connect, max_time);
         process::exit(0)
     }
     if args.filenames.len() > 1 && args.no_docker {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,14 @@ fn main() {
             }
         }
         process::exit(0)
-    } else if let Commands::Get { url, output } = args.command {
-        get_and_save(&url, output.as_deref());
+    } else if let Commands::Get {
+        url,
+        output,
+        timeout_connect,
+        max_time,
+    } = args.command
+    {
+        get_and_save(&url, output.as_deref(), timeout_connect, max_time);
         process::exit(0)
     }
     if args.filenames.len() > 1 && args.no_docker {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,14 @@ fn main() {
         max_time,
     } = args.command
     {
-        get_and_save(&url, &script, &output, timeout_connect, max_time, verbosity.clone());
+        get_and_save(
+            &url,
+            &script,
+            &output,
+            timeout_connect,
+            max_time,
+            verbosity.clone(),
+        );
         process::exit(0)
     }
     if args.filenames.len() > 1 && args.no_docker {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use std::{fs, process};
 //mod lib;
 //use crate::lib::ComposeYaml;
 use docker_pose::{
-    cmd_get_success_output_or_fail, get, get_service, get_slug, get_yml_content, print_names,
-    unwrap_filter_regex, unwrap_filter_tag, Args, Commands, ComposeYaml, DockerCommand, GitCommand,
-    Objects, ReplaceTag, Verbosity,
+    cmd_get_success_output_or_fail, get_and_save, get_service, get_slug, get_yml_content,
+    print_names, unwrap_filter_regex, unwrap_filter_tag, Args, Commands, ComposeYaml,
+    DockerCommand, GitCommand, Objects, ReplaceTag, Verbosity,
 };
 
 fn main() {
@@ -221,7 +221,7 @@ fn main() {
             // This was attended above in the code
         }
         Commands::Get { url } => {
-            get(&url);
+            get_and_save(&url);
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -550,3 +550,45 @@ pub fn string_script(s: &str) -> Result<(String, String), &'static str> {
     // should never end here
     Err("wrong expression")
 }
+
+/// Parser of headers in the form of "Name: value".
+/// Return a tuple of 2 strings: ("text1, "text2").
+///
+/// ```
+/// use docker_pose::header;
+///
+/// assert_eq!(header("abc: def"), Ok(("abc".to_string(), "def".to_string())));
+/// assert_eq!(header("a:b"), header("a: b"));
+/// assert_eq!(header("abc:"), Ok(("abc".to_string(), "".to_string())));
+/// assert_eq!(
+///     header("abc: def:more after->:"),
+///     Ok(("abc".to_string(), "def:more after->:".to_string()))
+/// );
+/// assert_eq!(header(""), Err("must be at least 3 characters long"));
+/// assert_eq!(header("a"), Err("must be at least 3 characters long"));
+/// assert_eq!(header("abc"), Err("separator symbol : not found in the header expression"));
+/// assert_eq!(header(":def"), Err("empty header name"));
+pub fn header(s: &str) -> Result<(String, String), &'static str> {
+    if s.len() < 3 {
+        return Err("must be at least 3 characters long");
+    }
+    let mut split = s.splitn(2, ':');
+    let left = split.next();
+    let right = split.next();
+    if let Some(left_text) = left {
+        if left_text == s {
+            return Err("separator symbol : not found in the header expression");
+        }
+        if left_text.is_empty() {
+            return Err("empty header name");
+        }
+        if let Some(right_text) = right {
+            return Ok((
+                left_text.trim_start().to_string(),
+                right_text.trim_start().to_string(),
+            ));
+        }
+    }
+    // should never end here
+    Err("wrong header expression")
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,6 @@
 use crate::verbose::Verbosity;
 use crate::{get_slug, DockerCommand};
+use clap_num::number_range;
 use colored::*;
 use regex::Regex;
 use serde_yaml::{to_string, Error, Mapping, Value};
@@ -499,4 +500,53 @@ pub fn get_compose_filename(
             }
         }
     }
+}
+
+pub fn positive_less_than_32(s: &str) -> Result<u8, String> {
+    number_range(s, 1, 32)
+}
+
+pub fn string_no_empty(s: &str) -> Result<String, &'static str> {
+    if s.is_empty() {
+        return Err("must be at least 1 character long");
+    }
+    Ok(s.to_string())
+}
+
+/// Parser of strings in the form of "text1:text2".
+/// Return a tuple of 2 strings: ("text1, "text2").
+///
+/// ```
+/// use docker_pose::string_script;
+///
+/// assert_eq!(string_script("abc:def"), Ok(("abc".to_string(), "def".to_string())));
+/// assert_eq!(string_script("abc:"), Ok(("abc".to_string(), "".to_string())));
+/// assert_eq!(
+///     string_script("abc:def:more after->:"),
+///     Ok(("abc".to_string(), "def:more after->:".to_string()))
+/// );
+/// assert_eq!(string_script(""), Err("must be at least 2 characters long"));
+/// assert_eq!(string_script("a"), Err("must be at least 2 characters long"));
+/// assert_eq!(string_script("abc"), Err("separator symbol : not found in the expression"));
+/// assert_eq!(string_script(":def"), Err("empty left expression"));
+pub fn string_script(s: &str) -> Result<(String, String), &'static str> {
+    if s.len() < 2 {
+        return Err("must be at least 2 characters long");
+    }
+    let mut split = s.splitn(2, ':');
+    let left = split.next();
+    let right = split.next();
+    if let Some(left_text) = left {
+        if left_text == s {
+            return Err("separator symbol : not found in the expression");
+        }
+        if left_text.is_empty() {
+            return Err("empty left expression");
+        }
+        if let Some(right_text) = right {
+            return Ok((left_text.to_string(), right_text.to_string()));
+        }
+    }
+    // should never end here
+    Err("wrong expression")
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -252,7 +252,7 @@ impl ComposeYaml {
             if stderr.to_lowercase().contains("no such image") {
                 if show_progress && replace_tag.offline {
                     eprintln!(
-                        "{}: manifest for image {} ... {} ",
+                        "{}: manifest for image {} ... {}",
                         "DEBUG".green(),
                         remote_image.yellow(),
                         "not found".purple()
@@ -305,7 +305,7 @@ impl ComposeYaml {
             {
                 if show_progress {
                     eprintln!(
-                        "{}: manifest for image {} ... {} ",
+                        "{}: manifest for image {} ... {}",
                         "DEBUG".green(),
                         remote_image.yellow(),
                         "not found".purple()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,28 @@ pub fn unwrap_filter_tag(filter: Option<&str>) -> Option<&str> {
 /// When expression has "=" the bool is true, when is "!="
 /// the bool is false.
 /// If the option passed is None, this method returns None as well.
+///
+/// ```
+/// use regex::Regex;
+/// use docker_pose::unwrap_filter_regex;
+///
+/// assert!(unwrap_filter_regex(None).is_none());
+///
+/// let expected_regex = Regex::new("mrsarm/").unwrap();
+/// let filter = unwrap_filter_regex(Some("regex=mrsarm/"));
+///
+/// assert!(filter.is_some());
+/// let filter = filter.unwrap();
+/// assert_eq!(filter.0.as_str(), expected_regex.as_str());
+/// assert_eq!(filter.1, true);
+///
+/// let filter = unwrap_filter_regex(Some("regex!=mrsarm/"));
+///
+/// assert!(filter.is_some());
+/// let filter = filter.unwrap();
+/// assert_eq!(filter.0.as_str(), expected_regex.as_str());
+/// assert_eq!(filter.1, false);
+/// ```
 pub fn unwrap_filter_regex(filter: Option<&str>) -> Option<(Regex, bool)> {
     filter.as_ref().map(|f| {
         if let Some(val) = f.strip_prefix("regex=") {
@@ -100,6 +122,13 @@ pub fn get_yml_content(filename: Option<&str>, verbosity: Verbosity) -> String {
 /// a tag name to be published in a docker registry, with
 /// only number, letters, the symbol "-" or the symbol ".",
 /// and no more than 63 characters long, all in lowercase.
+///
+/// ```
+/// use docker_pose::get_slug;
+///
+/// assert_eq!(get_slug("some/branch"), "some-branch".to_string());
+/// assert_eq!(get_slug("Yeap!spaces and UpperCase  "), "yeap-spaces-and-uppercase".to_string());
+/// ```
 pub fn get_slug(input: &str) -> String {
     let text = input.trim();
     let text = text.to_lowercase();

--- a/tests/run_integration_test.bats
+++ b/tests/run_integration_test.bats
@@ -46,3 +46,27 @@ setup() {
     # The only one changed:
     assert_output --partial "image: mrsarm/mongotail:3.1.1"
 }
+
+@test "can get a file with another name" {
+    run target/debug/pose get https://raw.githubusercontent.com/mrsarm/pose/main/tests/compose-remote-check.yaml -o ci-check.yaml
+    assert_success
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/main/tests/compose-remote-check.yaml ... found"
+    [ -f ci-check.yaml ]
+}
+
+@test "can get a file" {
+    run target/debug/pose get https://raw.githubusercontent.com/mrsarm/pose/main/tests/compose-remote-check.yaml
+    assert_success
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/main/tests/compose-remote-check.yaml ... found"
+    [ -f compose-remote-check.yaml ]
+}
+
+@test "can get a file from URL generated from script" {
+    run target/debug/pose get https://raw.githubusercontent.com/mrsarm/pose/never-exist/tests/compose-remote-check.yaml never-exist:main -o get-never.yaml
+    assert_success
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/never-exist/tests/compose-remote-check.yaml ... not found"
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/main/tests/compose-remote-check.yaml ... found"
+    [ -f get-never.yaml ]
+}
+
+# TODO check better not found cases

--- a/tests/run_integration_test.bats
+++ b/tests/run_integration_test.bats
@@ -3,6 +3,12 @@ setup() {
     load 'test_helper/bats-assert/load'
 }
 
+teardown_file() {
+    rm -f get-never.yaml
+    rm -f ci-check.yaml
+    rm -f compose-remote-check.yaml
+}
+
 @test "can list images with remote tag" {
     run target/debug/pose --verbose -f tests/compose-remote-check.yaml \
         list images --tag 3.1.1 --tag-filter "regex=mrsarm/"
@@ -69,4 +75,17 @@ setup() {
     [ -f get-never.yaml ]
 }
 
-# TODO check better not found cases
+@test "can get a file and not found it" {
+    run target/debug/pose get https://raw.githubusercontent.com/mrsarm/pose/never-exist/tests/compose-remote-check.yaml
+    assert_failure
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/never-exist/tests/compose-remote-check.yaml ... not found"
+    assert_output --partial "ERROR: Download failed"
+}
+
+@test "can get a file and not found it and not get the scripted version as well" {
+    run target/debug/pose get https://raw.githubusercontent.com/mrsarm/pose/never-exist/tests/compose-remote-check.yaml never-exist:not-exist-as-well
+    assert_failure
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/never-exist/tests/compose-remote-check.yaml ... not found"
+    assert_output --partial "DEBUG: Downloading https://raw.githubusercontent.com/mrsarm/pose/not-exist-as-well/tests/compose-remote-check.yaml ... not found"
+    assert_output --partial "ERROR: Download failed"
+}

--- a/tests/run_test.bats
+++ b/tests/run_test.bats
@@ -157,3 +157,28 @@ setup() {
     # because are not used in the example
     assert_output --partial "secrets"
 }
+
+@test "can detect invalid URL" {
+    run target/debug/pose get i-not-a-valid-url
+    assert_failure
+    assert_output --partial "ERROR: invalid URL - relative URL without a base"
+}
+
+@test "can detect invalid script expression" {
+    run target/debug/pose get http://localhost:1234 not-valid-script
+    assert_failure
+    assert_output --partial "invalid value 'not-valid-script' for '[SCRIPT]': separator symbol : not found in the expression"
+}
+
+@test "can handle unknown host" {
+    run target/debug/pose get http://host-unknown-2341.com.uy/file.txt a:b
+    assert_failure
+    assert_output --partial "DEBUG: Downloading http://host-unknown-2341.com.uy/file.txt ... failed"
+    assert_output --partial "ERROR: http://host-unknown-2341.com.uy/file.txt: Dns Failed"
+}
+
+@test "can detect URL without a filename" {
+    run target/debug/pose get http://host.com
+    assert_failure
+    assert_output --partial "ERROR: URL without filename, you have to provide the filename where to store the file with the argument -o, --output"
+}


### PR DESCRIPTION
v0.4 will have all the stuff from previous betas, plus what is included in this PR:

- `pose get <URL> [SCRIPT]`: download a file from an HTTP URL, if the resource doesn't exist, fallback to another URL generated editing the URL given with a SCRIPT provided in the form of _"text-to-replace:replacer"_.
- Improve binary size reduction, although an HTTP library was added offsetting the weight lost.